### PR TITLE
missing variable exception

### DIFF
--- a/business_rules/engine.py
+++ b/business_rules/engine.py
@@ -5,6 +5,7 @@ from typing import Union
 from .actions import BaseActions
 from .fields import FIELD_NO_INPUT
 from .variables import BaseVariables
+from .exceptions import MissingVariableException
 
 logger = logging.getLogger(__name__)
 
@@ -83,7 +84,13 @@ async def check_condition(condition, defined_variables):
     name = condition['name']
     op = condition['operator']
     value = condition['value']
-    operator_type = await _get_variable_value(defined_variables, name)
+
+    try:
+        operator_type = await _get_variable_value(defined_variables, name)
+    except MissingVariableException:
+        """If variable value is missing, than corresponding condition is false"""
+        return False
+
     if 'value_is_variable' in condition and condition['value_is_variable']:
         variable_name = value
         temp_value = await _get_variable_value(defined_variables, variable_name)

--- a/business_rules/exceptions.py
+++ b/business_rules/exceptions.py
@@ -1,0 +1,7 @@
+
+
+class MissingVariableException(BaseException):
+    """
+    Variable can raise this exception, if variable value is missing.
+    If exception raised, than corresponding exception is false.
+    """

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,2 +1,3 @@
 pytest
+pytest-asyncio
 mock==4.0.2

--- a/tests/test_missing.py
+++ b/tests/test_missing.py
@@ -1,0 +1,88 @@
+from business_rules.variables import BaseVariables, string_rule_variable
+from business_rules.actions import BaseActions, rule_action
+from business_rules.exceptions import MissingVariableException
+from business_rules import run
+import pytest
+
+
+class Payment:
+    def __init__(self, amount, type):
+        self.amount = amount
+        self.type = type
+
+
+class Order:
+    def __init__(self, name, payment):
+        self.name = name
+        self.payment = payment
+
+
+class Variables(BaseVariables):
+
+    def __init__(self, order):
+        self.order = order
+
+    @string_rule_variable()
+    async def order_payment_type(self):
+        if self.order.payment is None:
+            raise MissingVariableException()
+
+        return self.order.payment.type
+
+
+class Actions(BaseActions):
+    @rule_action()
+    async def approve(self):
+        return {'action': 'approve'}
+
+
+@pytest.mark.asyncio
+async def test_missing_variable_exception():
+    rule = {
+        'conditions': {
+            'all': [
+                {
+                    'name': 'order_payment_type',
+                    'operator': 'not_equal_to',
+                    'value': 'paypal'
+                }
+            ]
+        },
+        'actions': [
+            {
+                'name': 'approve'
+            }
+        ]
+    }
+    order = Order(
+        name='order',
+        payment=Payment(amount=10, type='credit_card')
+    )
+    result = await run(
+        rule=rule,
+        defined_variables=Variables(order),
+        defined_actions=Actions()
+    )
+    assert result == {'action_name': 'approve', 'action_params': {}, 'action_result': {'action': 'approve'}}
+
+    order = Order(
+        name='order',
+        payment=Payment(amount=10, type='paypal')
+    )
+    result = await run(
+        rule=rule,
+        defined_variables=Variables(order),
+        defined_actions=Actions()
+    )
+    assert result is None
+
+    order = Order(
+        name='order',
+        payment=None
+    )
+    result = await run(
+        rule=rule,
+        defined_variables=Variables(order),
+        defined_actions=Actions()
+    )
+    assert result is None


### PR DESCRIPTION
Added `MissingVariableException` exception.
User-defined variables can raise this exception, just in case, if the variable value is missing.
If the exception was raised, than corresponding conditions are negative(false).

Example:
we have an order, and each order has payment attribute, which contains payment country.
```
class Payment:
    type: str
    country: str
    
class Order:
    payment: Payment = None
```

we have 3 orders with corresponding payments:
1. Payment(country='DE')
2. Payment(country='AT')
3. none

if we have a condition: `payment_country` != 'DE', than in this case 2-3 orders will return True, but 3rd order has no payment.

Situations depend on business logic, so `MissingVariableException` will give more flexibility to user.
